### PR TITLE
Updates for synchronous motor

### DIFF
--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -313,7 +313,9 @@ AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &respons
 	// Send the command.
 	if (cmd != AXACommand::STATUS) {
 		ESP_LOGD(TAG, "Command: %s", cmd.c_str());
-	}
+    } else {
+        ESP_LOGV(TAG, "Command: %s", cmd.c_str());
+    }
 	this->write_str(cmd.c_str());
 	this->write_str("\r\n");
 
@@ -337,6 +339,8 @@ AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &respons
 					// Command echo.
 					if (cmd != AXACommand::STATUS)
 						ESP_LOGD(TAG, "Command echo received: %s", response_.c_str());
+                    else
+                        ESP_LOGV(TAG, "Command echo received: %s", response_.c_str());
 					echo_received = true;
 				} else if (response_.length() > 0) {
 					if (!echo_received && cmd != AXACommand::STATUS)
@@ -346,11 +350,14 @@ AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &respons
 						// The actual response.
 						if (cmd != AXACommand::STATUS)
 							ESP_LOGD(TAG, "Response: %d %s", response_code_, response_.c_str());
+                        else
+                            ESP_LOGV(TAG, "Response: %d %s", response_code_, response_.c_str());
 						response += response_;
 						return AXAResponseCode(response_code_);
 					} else {
 						// Garbage.
-						ESP_LOGW(TAG, "Garbage received: %s", response_.c_str());
+                        ESP_LOGW(TAG, "Garbage received:");
+                        ESP_LOG_BUFFER_HEXDUMP(TAG, response_.c_str(), response_.size(), ESP_LOG_WARN);
 					}
 				}
 				response_.erase();

--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -305,6 +305,10 @@ bool AXARemoteCover::is_at_target_() const {
 AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &response) {
 	// Flush UART before sending command.
 	this->flush();
+    while(this->available()) {
+        uint8_t c;
+        this->read_byte(&c);
+    }
 
 	// Send the command.
 	if (cmd != AXACommand::STATUS) {

--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -364,7 +364,7 @@ AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &respons
 			}
 		}
 
-		if (millis() - now > 25) {
+		if (millis() - now > 100) {
 			ESP_LOGE(TAG, "Timeout while waiting for response");
 			return AXAResponseCode::Invalid;
 		}

--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -97,10 +97,10 @@ void AXARemoteCover::loop() {
 	const uint32_t now = millis();
 
     //Update every 5 seconds
-    if (now - this->last_publish_time_ < 5000) {
+    if (now - this->last_update_time_ < 5000) {
         return;
     }
-    this->last_publish_time_ = now;
+    this->last_update_time_ = now;
 
 	AXAResponseCode response = this->send_cmd_(AXACommand::STATUS);
 

--- a/components/axaremote/cover/cover.h
+++ b/components/axaremote/cover/cover.h
@@ -58,7 +58,7 @@ protected:
 
 	uint32_t last_recompute_time_{0};
 	uint32_t start_close_time_{0};
-	uint32_t last_publish_time_{0};
+	uint32_t last_update_time_{0};
 	float target_position_{0};
 	float last_position_{0};
 	float lock_position_{0};

--- a/components/axaremote/cover/cover.h
+++ b/components/axaremote/cover/cover.h
@@ -59,7 +59,6 @@ protected:
 	uint32_t last_recompute_time_{0};
 	uint32_t start_close_time_{0};
 	uint32_t last_publish_time_{0};
-	uint32_t last_log_time_{0};
 	float target_position_{0};
 	float last_position_{0};
 	float lock_position_{0};


### PR DESCRIPTION
Hi,

This PR improves the compatibility with the synchronous version with two motors.
The main points are:
1. Reduced polling rate to reduce the risk of collisions. It seems the update rate in Home Assistant is also in the range of a few seconds, so I don't think this reduces the precision of the display.
2. Flush incoming buffer to skip data received from synchronization commands.
3. Increased timeout, this seemed necessary. I'm as of yet unsure why the response can take longer.

I've also added some more logging to aid in development. Unfortunately, the hexdump log will only show output with a default configured logger component. So we've access to the verbose logging of commands or de hexdump but not both.

This is still missing a retry scheme in case a command collided.