### PR TITLE
Flush incoming buffer

### DIFF
--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -308,6 +308,10 @@ bool AXARemoteCover::is_at_target_() const {
 AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &response) {
 	// Flush UART before sending command.
 	this->flush();
+    while(this->available()) {
+        uint8_t c;
+        this->read_byte(&c);
+    }
 
 	// Send the command.
 	if (cmd != AXACommand::STATUS) {


### PR DESCRIPTION
Flush the input buffer of bytes received before.
The `flush()` command only flushes the output buffer (which should be empty, but better safe than sorry)
