### PR TITLE
Increase timeout

### DIFF
--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -356,7 +356,7 @@ AXAResponseCode AXARemoteCover::send_cmd_(std::string &cmd, std::string &respons
 			}
 		}
 
-		if (millis() - now > 25) {
+		if (millis() - now > 100) {
 			ESP_LOGE(TAG, "Timeout while waiting for response");
 			return AXAResponseCode::Invalid;
 		}


### PR DESCRIPTION
It's not entirely certain why, but the synchronous version sometimes responds a bit later. Maybe because it sends synchronization commands between our command and the response. Maybe it also needs some time in firmware.