### PR TITLE
Retry alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ cover:
 - __polling_interval__ (Optional): The time between status update requests from the AXA Remote.
   Defaults to 0s (continuous polling). __auto_calibrate__ will not be accurate with a reduced
   polling interval.
+- __retry_interval__ (Optional): The time between retries in case a command fails to be transmitted. Defaults to 0s.
 
 ### Model specific configuration for the AXA Remote 2.0S
 
 To reduce the interference of this ESPHome External Component with the synchronisation messages of
-the AXA Remote 2.0S it is recommended to use a reduced polling interval of 5 seconds or more.
+the AXA Remote 2.0S it is recommended to use a reduced polling interval of 5 seconds or more and a retry interval of 1 second or more.
 
 ```
 cover:
@@ -210,6 +211,7 @@ cover:
     name: "AXA Remote 2.0S"
     close_duration: 50s
     polling_interval: 5s
+    retry_interval: 1s
 ```
 
 ### Calibration

--- a/components/axaremote/cover/__init__.py
+++ b/components/axaremote/cover/__init__.py
@@ -11,11 +11,13 @@ axaremote_ns = cg.esphome_ns.namespace('axaremote')
 AXARemoteCover = axaremote_ns.class_('AXARemoteCover', cg.Component, cover.Cover, uart.UARTDevice)
 
 CONF_AUTO_CALIBRATE = "auto_calibrate"
+CONF_RETRY_INTERVAL = "retry_interval"
 
 CONFIG_SCHEMA = cover.cover_schema(AXARemoteCover).extend(
     {
         cv.GenerateID(): cv.declare_id(AXARemoteCover),
         cv.Optional(CONF_POLLING_INTERVAL, default="0s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_RETRY_INTERVAL, default="0s"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_CLOSE_DURATION, default="50s"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_AUTO_CALIBRATE, default=False): bool,
     }
@@ -29,5 +31,6 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
 
     cg.add(var.set_polling_interval(config[CONF_POLLING_INTERVAL]))
+    cg.add(var.set_retry_interval(config[CONF_RETRY_INTERVAL]))
     cg.add(var.set_close_duration(config[CONF_CLOSE_DURATION]))
     cg.add(var.set_auto_calibrate(config[CONF_AUTO_CALIBRATE]))

--- a/components/axaremote/cover/cover.cpp
+++ b/components/axaremote/cover/cover.cpp
@@ -127,7 +127,7 @@ void AXARemoteCover::loop() {
 		poll_interval = this->polling_interval_;
 	} else {
 		//Update @ retry_interval
-		poll_interval = 1000;
+		poll_interval = this->retry_interval_;
 	}
 
 	uint32_t time_lapsed_since_last_poll = now - this->last_poll_time_;

--- a/components/axaremote/cover/cover.h
+++ b/components/axaremote/cover/cover.h
@@ -43,6 +43,7 @@ public:
 	void dump_config() override;
 	cover::CoverTraits get_traits() override;
 	void set_polling_interval(uint32_t polling_interval) { this->polling_interval_ = polling_interval; }
+	void set_retry_interval(uint32_t retry_interval) { this->retry_interval_ = retry_interval; }
 	void set_close_duration(uint32_t close_duration);
 	void set_auto_calibrate(bool auto_calibrate) { this->auto_calibrate_ = auto_calibrate; }
 	void loop();
@@ -56,6 +57,7 @@ protected:
 	float close_duration_;
 	float lock_duration_;
 	uint32_t polling_interval_;
+	uint32_t retry_interval_;
 	bool auto_calibrate_ = false;
 	bool power_outage_detected_ = false;
 


### PR DESCRIPTION
Hi,

I've looked at your retry scheme. I would like to propose an alternative. With your implementation I get messages about the loop being delayed too long. My implementation is less aggressive as it employs a larger delay between writes (I intend to make the delay configurable, just as poll_interval, so it can be set close to 0 in the future). It also ignores failed STATUS commands, as they normally aren't essential to be executed properly each time. Other commands are retried indefinitely until a success or a different command is issued. This will make it less likely that important commands such as 'CLOSE' are lost.

This PR is based on a slightly older master, but I can update it to be based on the latest commit if we go forward with this.

What do you think about this?
